### PR TITLE
Add onlinely.blank Bitrix module with installation wizard

### DIFF
--- a/local/modules/onlinely.blank/install/index.php
+++ b/local/modules/onlinely.blank/install/index.php
@@ -1,0 +1,81 @@
+<?php
+
+use Bitrix\Main\IO\Directory;
+use Bitrix\Main\Localization\Loc;
+use Bitrix\Main\ModuleManager;
+
+Loc::loadMessages(__FILE__);
+
+class onlinely_blank extends CModule
+{
+    public $MODULE_ID = 'onlinely.blank';
+    public $MODULE_GROUP_RIGHTS = 'Y';
+    public $MODULE_VERSION;
+    public $MODULE_VERSION_DATE;
+    public $MODULE_NAME;
+    public $MODULE_DESCRIPTION;
+    public $PARTNER_NAME;
+    public $PARTNER_URI;
+
+    public function __construct()
+    {
+        $arModuleVersion = [];
+        include __DIR__ . '/version.php';
+
+        $this->MODULE_VERSION = $arModuleVersion['VERSION'] ?? '1.0.0';
+        $this->MODULE_VERSION_DATE = $arModuleVersion['VERSION_DATE'] ?? date('Y-m-d');
+        $this->MODULE_NAME = Loc::getMessage('ONLINELY_BLANK_MODULE_NAME');
+        $this->MODULE_DESCRIPTION = Loc::getMessage('ONLINELY_BLANK_MODULE_DESCRIPTION');
+        $this->PARTNER_NAME = Loc::getMessage('ONLINELY_BLANK_PARTNER_NAME');
+        $this->PARTNER_URI = Loc::getMessage('ONLINELY_BLANK_PARTNER_URI');
+    }
+
+    public function DoInstall(): void
+    {
+        global $APPLICATION;
+
+        if (!ModuleManager::isModuleInstalled($this->MODULE_ID)) {
+            $this->installFiles();
+            ModuleManager::registerModule($this->MODULE_ID);
+        }
+
+        $APPLICATION->IncludeAdminFile(
+            Loc::getMessage('ONLINELY_BLANK_INSTALL_TITLE'),
+            __DIR__ . '/step.php'
+        );
+    }
+
+    public function DoUninstall(): void
+    {
+        global $APPLICATION;
+
+        if (ModuleManager::isModuleInstalled($this->MODULE_ID)) {
+            $this->uninstallFiles();
+            ModuleManager::unRegisterModule($this->MODULE_ID);
+        }
+
+        $APPLICATION->IncludeAdminFile(
+            Loc::getMessage('ONLINELY_BLANK_UNINSTALL_TITLE'),
+            __DIR__ . '/unstep.php'
+        );
+    }
+
+    private function installFiles(): void
+    {
+        $wizardSource = __DIR__ . '/wizards/onlinely/blank';
+        $wizardTarget = $_SERVER['DOCUMENT_ROOT'] . '/bitrix/wizards/onlinely/blank';
+
+        if (Directory::isDirectoryExists($wizardSource)) {
+            CopyDirFiles($wizardSource, $wizardTarget, true, true);
+        }
+    }
+
+    private function uninstallFiles(): void
+    {
+        $wizardTarget = $_SERVER['DOCUMENT_ROOT'] . '/bitrix/wizards/onlinely/blank';
+
+        if (Directory::isDirectoryExists($wizardTarget)) {
+            Directory::deleteDirectory($wizardTarget);
+        }
+    }
+}

--- a/local/modules/onlinely.blank/install/step.php
+++ b/local/modules/onlinely.blank/install/step.php
@@ -1,0 +1,19 @@
+<?php
+
+use Bitrix\Main\Localization\Loc;
+
+if (!defined('B_PROLOG_INCLUDED') || B_PROLOG_INCLUDED !== true) {
+    die();
+}
+
+Loc::loadMessages(__FILE__);
+?>
+<form action="/bitrix/admin/wizard_install.php" method="get">
+    <input type="hidden" name="lang" value="<?= LANGUAGE_ID ?>">
+    <input type="hidden" name="wizardName" value="onlinely:blank">
+    <input type="hidden" name="install" value="Y">
+    <?= bitrix_sessid_post() ?>
+    <p><?= Loc::getMessage('ONLINELY_BLANK_INSTALL_SUCCESS') ?></p>
+    <p><?= Loc::getMessage('ONLINELY_BLANK_INSTALL_WIZARD_INFO') ?></p>
+    <input type="submit" name="install_wizard" value="<?= Loc::getMessage('ONLINELY_BLANK_INSTALL_RUN_WIZARD') ?>">
+</form>

--- a/local/modules/onlinely.blank/install/unstep.php
+++ b/local/modules/onlinely.blank/install/unstep.php
@@ -1,0 +1,11 @@
+<?php
+
+use Bitrix\Main\Localization\Loc;
+
+if (!defined('B_PROLOG_INCLUDED') || B_PROLOG_INCLUDED !== true) {
+    die();
+}
+
+Loc::loadMessages(__FILE__);
+?>
+<p><?= Loc::getMessage('ONLINELY_BLANK_UNINSTALL_SUCCESS') ?></p>

--- a/local/modules/onlinely.blank/install/version.php
+++ b/local/modules/onlinely.blank/install/version.php
@@ -1,0 +1,6 @@
+<?php
+
+$arModuleVersion = [
+    'VERSION' => '1.0.0',
+    'VERSION_DATE' => '2025-02-06',
+];

--- a/local/modules/onlinely.blank/install/wizards/onlinely/blank/.description.php
+++ b/local/modules/onlinely.blank/install/wizards/onlinely/blank/.description.php
@@ -1,0 +1,17 @@
+<?php
+
+use Bitrix\Main\Localization\Loc;
+
+Loc::loadMessages(__FILE__);
+
+$arDescription = [
+    'NAME' => Loc::getMessage('ONLINELY_BLANK_WIZARD_NAME'),
+    'DESCRIPTION' => Loc::getMessage('ONLINELY_BLANK_WIZARD_DESCRIPTION'),
+    'VERSION' => '1.0.0',
+    'START_TYPE' => 'window',
+    'WIZARD_TYPE' => 'solution',
+    'IMAGE' => 'images/screenshot.png',
+    'LANG' => 'ru',
+    'PARTNER_NAME' => Loc::getMessage('ONLINELY_BLANK_PARTNER_NAME'),
+    'PARTNER_URI' => Loc::getMessage('ONLINELY_BLANK_PARTNER_URI'),
+];

--- a/local/modules/onlinely.blank/install/wizards/onlinely/blank/.settings.php
+++ b/local/modules/onlinely.blank/install/wizards/onlinely/blank/.settings.php
@@ -1,0 +1,7 @@
+<?php
+
+$arWizardDescription = [
+    'NAME' => 'onlinely.blank',
+    'DESCRIPTION' => 'Onlinely Blank Wizard',
+    'VERSION' => '1.0.0',
+];

--- a/local/modules/onlinely.blank/install/wizards/onlinely/blank/index.php
+++ b/local/modules/onlinely.blank/install/wizards/onlinely/blank/index.php
@@ -1,0 +1,40 @@
+<?php
+
+use Bitrix\Main\Localization\Loc;
+
+if (!defined('B_PROLOG_INCLUDED') || B_PROLOG_INCLUDED !== true) {
+    die();
+}
+
+Loc::loadMessages(__FILE__);
+
+class OnlinelyBlankStartStep extends CWizardStep
+{
+    public function InitStep(): void
+    {
+        $this->SetStepId('start');
+        $this->SetTitle(Loc::getMessage('ONLINELY_BLANK_WIZARD_STEP_START_TITLE'));
+        $this->SetNextStep('finish');
+        $this->SetNextCaption(Loc::getMessage('ONLINELY_BLANK_WIZARD_NEXT'));
+    }
+
+    public function ShowStep(): void
+    {
+        $this->content = '<p>' . Loc::getMessage('ONLINELY_BLANK_WIZARD_STEP_START_TEXT') . '</p>';
+    }
+}
+
+class OnlinelyBlankFinishStep extends CWizardStep
+{
+    public function InitStep(): void
+    {
+        $this->SetStepId('finish');
+        $this->SetTitle(Loc::getMessage('ONLINELY_BLANK_WIZARD_STEP_FINISH_TITLE'));
+        $this->SetFinishStep(true);
+    }
+
+    public function ShowStep(): void
+    {
+        $this->content = '<p>' . Loc::getMessage('ONLINELY_BLANK_WIZARD_STEP_FINISH_TEXT') . '</p>';
+    }
+}

--- a/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/en/.description.php
+++ b/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/en/.description.php
@@ -1,0 +1,6 @@
+<?php
+
+$MESS['ONLINELY_BLANK_WIZARD_NAME'] = 'Onlinely Template Setup Wizard';
+$MESS['ONLINELY_BLANK_WIZARD_DESCRIPTION'] = 'Prepares the project structure and basic settings.';
+$MESS['ONLINELY_BLANK_PARTNER_NAME'] = 'Onlinely';
+$MESS['ONLINELY_BLANK_PARTNER_URI'] = 'https://onlinely.ru';

--- a/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/en/index.php
+++ b/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/en/index.php
@@ -1,0 +1,7 @@
+<?php
+
+$MESS['ONLINELY_BLANK_WIZARD_STEP_START_TITLE'] = 'Welcome';
+$MESS['ONLINELY_BLANK_WIZARD_STEP_START_TEXT'] = 'The wizard will prepare the project structure and verify basic settings.';
+$MESS['ONLINELY_BLANK_WIZARD_STEP_FINISH_TITLE'] = 'Done';
+$MESS['ONLINELY_BLANK_WIZARD_STEP_FINISH_TEXT'] = 'Installation is complete. You can proceed with project configuration.';
+$MESS['ONLINELY_BLANK_WIZARD_NEXT'] = 'Continue';

--- a/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/ru/.description.php
+++ b/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/ru/.description.php
@@ -1,0 +1,6 @@
+<?php
+
+$MESS['ONLINELY_BLANK_WIZARD_NAME'] = 'Мастер установки шаблона Onlinely';
+$MESS['ONLINELY_BLANK_WIZARD_DESCRIPTION'] = 'Подготовит структуру проекта и базовые настройки.';
+$MESS['ONLINELY_BLANK_PARTNER_NAME'] = 'Onlinely';
+$MESS['ONLINELY_BLANK_PARTNER_URI'] = 'https://onlinely.ru';

--- a/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/ru/index.php
+++ b/local/modules/onlinely.blank/install/wizards/onlinely/blank/lang/ru/index.php
@@ -1,0 +1,7 @@
+<?php
+
+$MESS['ONLINELY_BLANK_WIZARD_STEP_START_TITLE'] = 'Добро пожаловать';
+$MESS['ONLINELY_BLANK_WIZARD_STEP_START_TEXT'] = 'Мастер подготовит структуру проекта и проверит базовые настройки.';
+$MESS['ONLINELY_BLANK_WIZARD_STEP_FINISH_TITLE'] = 'Готово';
+$MESS['ONLINELY_BLANK_WIZARD_STEP_FINISH_TEXT'] = 'Установка завершена. Вы можете перейти к настройке проекта.';
+$MESS['ONLINELY_BLANK_WIZARD_NEXT'] = 'Продолжить';

--- a/local/modules/onlinely.blank/lang/en/install/index.php
+++ b/local/modules/onlinely.blank/lang/en/install/index.php
@@ -1,0 +1,8 @@
+<?php
+
+$MESS['ONLINELY_BLANK_MODULE_NAME'] = 'Onlinely Project Template';
+$MESS['ONLINELY_BLANK_MODULE_DESCRIPTION'] = 'Ready-to-use 1C-Bitrix project skeleton with installation wizard and structure examples.';
+$MESS['ONLINELY_BLANK_PARTNER_NAME'] = 'Onlinely';
+$MESS['ONLINELY_BLANK_PARTNER_URI'] = 'https://onlinely.ru';
+$MESS['ONLINELY_BLANK_INSTALL_TITLE'] = 'Installing Onlinely template';
+$MESS['ONLINELY_BLANK_UNINSTALL_TITLE'] = 'Uninstalling Onlinely template';

--- a/local/modules/onlinely.blank/lang/en/install/step.php
+++ b/local/modules/onlinely.blank/lang/en/install/step.php
@@ -1,0 +1,5 @@
+<?php
+
+$MESS['ONLINELY_BLANK_INSTALL_SUCCESS'] = 'Module installed successfully.';
+$MESS['ONLINELY_BLANK_INSTALL_WIZARD_INFO'] = 'Run the installation wizard to configure the project.';
+$MESS['ONLINELY_BLANK_INSTALL_RUN_WIZARD'] = 'Run installation wizard';

--- a/local/modules/onlinely.blank/lang/en/install/unstep.php
+++ b/local/modules/onlinely.blank/lang/en/install/unstep.php
@@ -1,0 +1,3 @@
+<?php
+
+$MESS['ONLINELY_BLANK_UNINSTALL_SUCCESS'] = 'Module has been removed.';

--- a/local/modules/onlinely.blank/lang/ru/install/index.php
+++ b/local/modules/onlinely.blank/lang/ru/install/index.php
@@ -1,0 +1,8 @@
+<?php
+
+$MESS['ONLINELY_BLANK_MODULE_NAME'] = 'Шаблон проекта от Onlinely';
+$MESS['ONLINELY_BLANK_MODULE_DESCRIPTION'] = 'Готовый каркас проекта 1С-Битрикс с мастером установки и примером структуры.';
+$MESS['ONLINELY_BLANK_PARTNER_NAME'] = 'Onlinely';
+$MESS['ONLINELY_BLANK_PARTNER_URI'] = 'https://onlinely.ru';
+$MESS['ONLINELY_BLANK_INSTALL_TITLE'] = 'Установка шаблона Onlinely';
+$MESS['ONLINELY_BLANK_UNINSTALL_TITLE'] = 'Удаление шаблона Onlinely';

--- a/local/modules/onlinely.blank/lang/ru/install/step.php
+++ b/local/modules/onlinely.blank/lang/ru/install/step.php
@@ -1,0 +1,5 @@
+<?php
+
+$MESS['ONLINELY_BLANK_INSTALL_SUCCESS'] = 'Модуль успешно установлен.';
+$MESS['ONLINELY_BLANK_INSTALL_WIZARD_INFO'] = 'Для настройки проекта запустите мастер установки.';
+$MESS['ONLINELY_BLANK_INSTALL_RUN_WIZARD'] = 'Запустить мастер установки';

--- a/local/modules/onlinely.blank/lang/ru/install/unstep.php
+++ b/local/modules/onlinely.blank/lang/ru/install/unstep.php
@@ -1,0 +1,3 @@
+<?php
+
+$MESS['ONLINELY_BLANK_UNINSTALL_SUCCESS'] = 'Модуль удалён.';

--- a/local/modules/onlinely.blank/module.php
+++ b/local/modules/onlinely.blank/module.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!defined('B_PROLOG_INCLUDED') || B_PROLOG_INCLUDED !== true) {
+    die();
+}
+
+require_once __DIR__ . '/install/index.php';


### PR DESCRIPTION
### Motivation
- Provide a ready-to-publish 1C-Bitrix Marketplace module scaffold for partner `Onlinely` that includes an installation/uninstallation flow and a setup wizard.
- Ship localization for Russian and English so the module UI and wizard display proper partner and install messages.

### Description
- Added module bootstrap and installer logic in `local/modules/onlinely.blank/install/index.php` that registers/unregisters the module and copies/removes the wizard files to `/bitrix/wizards/onlinely/blank`.
- Added module metadata `version.php` and module entry `module.php` that loads installer logic. 
- Implemented installer UI pages `install/step.php` and `install/unstep.php`, and updated the install step to launch the wizard via `/bitrix/admin/wizard_install.php` with `wizardName=onlinely:blank`.
- Added a minimal wizard under `install/wizards/onlinely/blank` with `.description.php`, `.settings.php`, `index.php`, and language packs under `lang/ru` and `lang/en`, and corrected an English translation string to use `configuration`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969fb91da30833286347449493ece86)